### PR TITLE
Deactivate SpaceAfterCloseBracket PEAR Rule

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -78,6 +78,9 @@
     <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
         <severity>0</severity>
     </rule>
+    <rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterCloseBracket">
+        <severity>0</severity>
+    </rule>
     <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
         <severity>0</severity>
     </rule>


### PR DESCRIPTION
This rules cause problem with some Symfony bundle generated code like sonata-admin.

Here an example.

``` php
protected function configureListFields(ListMapper $listMapper)
{
    $listMapper
        ->add('ref')
        ->add('isValid')
        ->add('_action', 'actions', array(
            'actions' => array(
                'show'      => array(),
                'edit'      => array(),
            )
        ))
    ;
}
```

This will throw the following error 'Space after closing parenthesis of function call prohibited'. But I don't think this is prohibited on Symfony2 coding standards.

What is your think ?
