### PR TITLE
Allow newer php_codesniffer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "A PHP_CodeSniffer standard for Symfony 2 applications",
     "license": "MIT",
     "require": {
-        "squizlabs/php_codesniffer": "~2.0.0"
+        "squizlabs/php_codesniffer": "^2.0.0"
     },
     "target-dir": "leaphub/phpcs/Symfony2",
     "extra": {


### PR DESCRIPTION
The installation of phpcs-symfony2-standard via composer fails when using `squizlabs/php_codesniffer 2.2.0`. I cannot see any problems, why the sniffs cannot work with 2.2.*, so the version constraint should be updated.