### PR TITLE
Fix inheritdoc check

### DIFF
--- a/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Sniffs/Commenting/FunctionCommentSniff.php
@@ -109,7 +109,7 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commen
 
         $content = $phpcsFile->getTokensAsString($start, ($end - $start));
 
-        return preg_match('#{@inheritdoc}#i', $content) === 1;
+        return preg_match('#@inheritdoc#i', $content) === 1;
     } // end isInheritDoc()
 
     /**


### PR DESCRIPTION
{@inheritdoc} only inherits the description.

See https://twitter.com/mvriel/status/615942341572976640
