### PR TITLE
Refs #7 - Fixing issue with PSR-2 conflict with Zend ruleset

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -62,6 +62,9 @@
 
         <!-- do not check line length -->
         <exclude name="Generic.Files.LineLength"/>
+        
+        <!-- covered by Squiz FunctionDeclarationSniff -->
+        <exclude name="Generic.Functions.OpeningFunctionBraceBsdAllman.BraceOnSameLine"/>
     </rule>
 
     <!-- Don't enforce Zend's private member underscores -->


### PR DESCRIPTION
Now allows http://www.php-fig.org/psr/psr-2/#4-4-method-arguments with
arguments on multiple lines.
